### PR TITLE
Implement core simulation logic for Grid and MaterialRegistry

### DIFF
--- a/Engine.cpp
+++ b/Engine.cpp
@@ -19,8 +19,8 @@ Engine::Engine() : m_isRunning(true) {
 
     m_materialRegistry = std::make_unique<MaterialRegistry>();
 
-    // Assuming Grid takes width and height
-    m_grid = std::make_unique<Grid>(100, 100); // Example dimensions
+    // Assuming Grid takes width and height, and now MaterialRegistry
+    m_grid = std::make_unique<Grid>(100, 100, *m_materialRegistry); // Example dimensions, added m_materialRegistry
 
     // Assuming Renderer takes width and height, or a reference to the window
     // If Renderer needs window dimensions, we might need to get them from m_window
@@ -88,6 +88,7 @@ void Engine::run() {
 
         if (m_grid) {
             m_grid->update(deltaTime);
+            m_grid->swapBuffers(); // Add this line
         }
 
         if (m_renderer && m_grid) {

--- a/Grid.cpp
+++ b/Grid.cpp
@@ -1,31 +1,149 @@
 #include "Grid.h"
-#include <iostream> // For debug messages
+#include <vector>
+#include <algorithm> // For std::fill and std::swap
+#include <cstdlib>   // For rand()
+// Removed iostream as it's no longer used for debug messages here.
 
-Grid::Grid(int width, int height) : m_width(width), m_height(height), m_grid_data(nullptr) {
-    std::cout << "Grid: Constructor called with width=" << width << ", height=" << height << std::endl;
-    // Initialize m_grid_data here if it's a pointer to dynamically allocated memory
-    // For example, m_grid_data = new Cell[width * height];
-    // For now, it's just a void pointer placeholder.
+Grid::Grid(int width, int height, MaterialRegistry& materialRegistry)
+    : m_width(width), m_height(height), m_materialRegistry(materialRegistry) {
+    m_readCells.resize(static_cast<size_t>(width) * height);
+    m_writeCells.resize(static_cast<size_t>(width) * height);
+
+    std::fill(m_readCells.begin(), m_readCells.end(), MaterialID::Empty);
+    std::fill(m_writeCells.begin(), m_writeCells.end(), MaterialID::Empty);
 }
 
 Grid::~Grid() {
-    std::cout << "Grid: Destructor called." << std::endl;
-    // If m_grid_data was dynamically allocated, delete it here.
-    // For example, if m_grid_data was Cell*, then delete[] static_cast<Cell*>(m_grid_data);
+    // No explicit cleanup needed for std::vector members like m_readCells and m_writeCells.
+    // m_materialRegistry is a reference, so its lifetime is managed externally.
 }
 
-void Grid::update(float deltaTime) {
-    // std::cout << "Grid: update called with deltaTime = " << deltaTime << std::endl; // Can be too verbose
-    // Actual grid simulation logic (sand falling, etc.) will go here.
+size_t Grid::toIndex(int x, int y) const {
+    // Assuming x and y are always within bounds [0, m_width-1] and [0, m_height-1] respectively
+    // when this function is called internally by getCell/setCell after bounds checking.
+    return static_cast<size_t>(y) * m_width + static_cast<size_t>(x);
 }
 
-void Grid::placeSand(int x, int y) {
-    std::cout << "Grid: placeSand called at (" << x << ", " << y << ")" << std::endl;
-    if (x >= 0 && x < m_width && y >= 0 && y < m_height) {
-        // Logic to place sand at the given grid cell.
-        // This would involve modifying m_grid_data.
-        std::cout << "Grid: Sand placed at valid coordinates (" << x << ", " << y << ")" << std::endl;
-    } else {
-        std::cout << "Grid: Attempted to place sand outside grid boundaries at (" << x << ", " << y << ")" << std::endl;
+void Grid::swapBuffers() {
+    m_readCells.swap(m_writeCells);
+}
+
+MaterialID Grid::getCell(int x, int y) const {
+    if (x < 0 || x >= m_width || y < 0 || y >= m_height) {
+        // Return a "boundary" material or handle error. Rock is a solid, unmovable material.
+        return MaterialID::Rock;
+    }
+    return m_readCells[toIndex(x, y)];
+}
+
+void Grid::setCell(int x, int y, MaterialID material) {
+    if (x < 0 || x >= m_width || y < 0 || y >= m_height) {
+        // Out of bounds, do nothing or log an error.
+        return;
+    }
+    m_writeCells[toIndex(x, y)] = material;
+}
+
+void Grid::update(float deltaTime) { // Added deltaTime parameter
+    // deltaTime is currently unused in the simulation logic.
+    m_writeCells = m_readCells;
+
+    for (int y = m_height - 2; y >= 0; --y) {
+        for (int x = 0; x < m_width; ++x) {
+            MaterialID currentMaterialID = m_readCells[toIndex(x, y)];
+
+            if (currentMaterialID == MaterialID::Empty || currentMaterialID == MaterialID::Rock) {
+                continue;
+            }
+            const MaterialDefinition& currentMaterialDef = m_materialRegistry.getMaterial(currentMaterialID);
+
+            switch (currentMaterialID) {
+                case MaterialID::Sand: {
+                    MaterialID belowMaterialID = m_readCells[toIndex(x, y + 1)];
+                    const MaterialDefinition& belowMaterialDef = m_materialRegistry.getMaterial(belowMaterialID);
+                    if (belowMaterialDef.density < currentMaterialDef.density) {
+                        m_writeCells[toIndex(x, y)] = belowMaterialID;
+                        m_writeCells[toIndex(x, y + 1)] = currentMaterialID;
+                        continue;
+                    }
+
+                    bool checkLeftFirst = (rand() % 2 == 0);
+                    for (int i = 0; i < 2; ++i) {
+                        int diagX = x + (checkLeftFirst ? -1 : 1);
+                        if (i == 1) diagX = x + (checkLeftFirst ? 1 : -1);
+                        if (diagX >= 0 && diagX < m_width) {
+                            MaterialID diagMaterialID = m_readCells[toIndex(diagX, y + 1)];
+                            const MaterialDefinition& diagMaterialDef = m_materialRegistry.getMaterial(diagMaterialID);
+                            if (diagMaterialDef.density < currentMaterialDef.density) {
+                                m_writeCells[toIndex(x, y)] = MaterialID::Empty;
+                                m_writeCells[toIndex(diagX, y + 1)] = currentMaterialID;
+                                goto next_particle_in_grid;
+                            }
+                        }
+                    }
+                    break;
+                }
+                case MaterialID::Water: {
+                    MaterialID belowWaterMaterialID = m_readCells[toIndex(x, y + 1)];
+                    const MaterialDefinition& belowWaterMaterialDef = m_materialRegistry.getMaterial(belowWaterMaterialID);
+                    if (belowWaterMaterialDef.density < currentMaterialDef.density) {
+                        m_writeCells[toIndex(x, y)] = belowWaterMaterialID;
+                        m_writeCells[toIndex(x, y + 1)] = currentMaterialID;
+                        continue;
+                    }
+
+                    int dispersionLimit = 10;
+                    int furthestRightX = -1; // Furthest it can go to the right
+                    for (int i = 1; i <= dispersionLimit; ++i) {
+                        int targetX = x + i;
+                        if (targetX >= m_width) break;
+                        MaterialID targetMaterialID = m_readCells[toIndex(targetX, y)];
+                        const MaterialDefinition& targetMaterialDef = m_materialRegistry.getMaterial(targetMaterialID);
+                        if (targetMaterialDef.density < currentMaterialDef.density) { // Can flow into less dense (includes Empty)
+                            furthestRightX = targetX;
+                        } else { break; }
+                    }
+
+                    int furthestLeftX = -1; // Furthest it can go to the left
+                    for (int i = 1; i <= dispersionLimit; ++i) {
+                        int targetX = x - i;
+                        if (targetX < 0) break;
+                        MaterialID targetMaterialID = m_readCells[toIndex(targetX, y)];
+                        const MaterialDefinition& targetMaterialDef = m_materialRegistry.getMaterial(targetMaterialID);
+                        if (targetMaterialDef.density < currentMaterialDef.density) { // Can flow into less dense
+                            furthestLeftX = targetX;
+                        } else { break; }
+                    }
+
+                    int finalTargetX = -1;
+                    bool canGoLeft = (furthestLeftX != -1);
+                    bool canGoRight = (furthestRightX != -1);
+
+                    if (canGoLeft && canGoRight) {
+                        finalTargetX = (rand() % 2 == 0) ? furthestLeftX : furthestRightX;
+                    } else if (canGoLeft) {
+                        finalTargetX = furthestLeftX;
+                    } else if (canGoRight) {
+                        finalTargetX = furthestRightX;
+                    }
+
+                    if (finalTargetX != -1) {
+                        // Water moves to finalTargetX, original cell (x,y) becomes what was at finalTargetX
+                        // If finalTargetX was Empty, (x,y) becomes Empty.
+                        // This is a swap to allow less dense materials (like air/empty) to be displaced.
+                        MaterialID materialAtTarget = m_readCells[toIndex(finalTargetX, y)];
+                        m_writeCells[toIndex(x, y)] = materialAtTarget;
+                        m_writeCells[toIndex(finalTargetX, y)] = currentMaterialID;
+                        continue;
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+            next_particle_in_grid:;
+        }
     }
 }
+
+// Removed Grid::placeSand(int x, y)

--- a/Grid.h
+++ b/Grid.h
@@ -1,17 +1,29 @@
 #pragma once
 
+#include "MaterialRegistry.h" // Added
+#include <vector>             // Added
+
 class Grid {
 public:
-    Grid(int width, int height);
+    Grid(int width, int height, MaterialRegistry& materialRegistry); // Updated constructor
     ~Grid();
 
-    void update(float deltaTime);
-    void placeSand(int x, int y);
+    void update(float deltaTime); // Changed signature
+    MaterialID getCell(int x, int y) const; // Added
+    void setCell(int x, int y, MaterialID material); // Added
+    void swapBuffers(); // Added
+    // void placeSand(int x, int y); // Removed
+
     // Add other grid-related methods here
 
 private:
+    size_t toIndex(int x, int y) const; // Added private helper
+
     int m_width;
     int m_height;
-    // Placeholder for grid data structure
-    void* m_grid_data;
+
+    // Changed m_grid_data to specific cell buffers and material registry
+    std::vector<MaterialID> m_readCells;
+    std::vector<MaterialID> m_writeCells;
+    MaterialRegistry& m_materialRegistry;
 };

--- a/MaterialRegistry.cpp
+++ b/MaterialRegistry.cpp
@@ -1,38 +1,31 @@
 #include "MaterialRegistry.h"
-#include <iostream> // For debug messages
-#include <algorithm> // For std::find_if
+// Removed iostream and algorithm includes as they are no longer needed.
 
 MaterialRegistry::MaterialRegistry() {
-    std::cout << "MaterialRegistry: Constructor called." << std::endl;
-    // Initialize default materials or leave empty.
+    m_materials.clear(); // Clear existing materials, if any.
+    // Resize to hold all MaterialID types. The size should be dynamic if more materials are added.
+    // For now, hardcoding based on the current number of MaterialIDs.
+    // Consider using MaterialID::Count or similar if the enum gets larger.
+    m_materials.resize(4);
+
+    m_materials[static_cast<size_t>(MaterialID::Empty)] = {MaterialID::Empty, "Empty", COLOR_EMPTY, 0.0f};
+    m_materials[static_cast<size_t>(MaterialID::Sand)] = {MaterialID::Sand, "Sand", COLOR_SAND, 1.5f};
+    m_materials[static_cast<size_t>(MaterialID::Rock)] = {MaterialID::Rock, "Rock", COLOR_ROCK, 2.0f};
+    m_materials[static_cast<size_t>(MaterialID::Water)] = {MaterialID::Water, "Water", COLOR_WATER, 1.0f};
 }
 
 MaterialRegistry::~MaterialRegistry() {
-    std::cout << "MaterialRegistry: Destructor called." << std::endl;
-    // Clean up any resources if necessary.
+    // Destructor remains the same, no specific cleanup needed for m_materials unless it holds pointers.
 }
 
-void MaterialRegistry::registerMaterial(const Material& material) {
-    // Check if material with the same name already exists to prevent duplicates
-    auto it = std::find_if(m_materials.begin(), m_materials.end(),
-                           [&](const Material& m) { return m.name == material.name; });
-
-    if (it == m_materials.end()) {
-        m_materials.push_back(material);
-        std::cout << "MaterialRegistry: Registered material \"" << material.name << "\"." << std::endl;
-    } else {
-        std::cout << "MaterialRegistry: Material with name \"" << material.name << "\" already exists. Not registering." << std::endl;
+const MaterialDefinition& MaterialRegistry::getMaterial(MaterialID id) const {
+    size_t index = static_cast<size_t>(id);
+    if (index < m_materials.size()) {
+        return m_materials[index];
     }
-}
-
-const Material* MaterialRegistry::getMaterial(const std::string& name) const {
-    auto it = std::find_if(m_materials.begin(), m_materials.end(),
-                           [&](const Material& m) { return m.name == name; });
-
-    if (it != m_materials.end()) {
-        return &(*it);
-    } else {
-        std::cout << "MaterialRegistry: Material with name \"" << name << "\" not found." << std::endl;
-        return nullptr;
-    }
+    // Fallback for invalid ID. This case should ideally not be reached if MaterialIDs are used correctly.
+    // Returning Rock as a default, but this could also be an assertion or throw an error.
+    // It might be better to return a const reference to a static default MaterialDefinition
+    // or handle the error more explicitly depending on game's error handling strategy.
+    return m_materials[static_cast<size_t>(MaterialID::Rock)];
 }

--- a/MaterialRegistry.h
+++ b/MaterialRegistry.h
@@ -1,23 +1,32 @@
 #pragma once
 
 #include <string>
-#include <vector> // Or some other suitable container
+#include <vector>
+#include <SFML/Graphics/Color.hpp> // Added for sf::Color
 
-// Placeholder for Material type
-struct Material {
+enum class MaterialID { Empty, Sand, Rock, Water };
+
+struct MaterialDefinition {
+    MaterialID id;
     std::string name;
-    // Add other material properties here (e.g., color, density, etc.)
+    sf::Color color;
+    float density;
 };
+
+// Color Constants
+const sf::Color COLOR_EMPTY = sf::Color::Black;
+const sf::Color COLOR_SAND = sf::Color::Yellow;
+const sf::Color COLOR_ROCK = sf::Color(128, 128, 128); // Gray
+const sf::Color COLOR_WATER = sf::Color::Blue;
 
 class MaterialRegistry {
 public:
     MaterialRegistry();
     ~MaterialRegistry();
 
-    void registerMaterial(const Material& material);
-    const Material* getMaterial(const std::string& name) const;
+    const MaterialDefinition& getMaterial(MaterialID id) const;
     // Add other material management methods here
 
 private:
-    std::vector<Material> m_materials;
+    std::vector<MaterialDefinition> m_materials; // Changed Material to MaterialDefinition
 };


### PR DESCRIPTION
This commit introduces the physics and rules for the cellular automata simulation:

- MaterialRegistry:
  - Defined MaterialID enum (Empty, Sand, Rock, Water) and MaterialDefinition struct (ID, name, color, density).
  - Constructor now populates definitions for all material types.
  - getMaterial(MaterialID) provides access to material properties.

- Grid:
  - Uses m_readCells and m_writeCells (std::vector<MaterialID>) for simulation state.
  - Constructor initializes cells to Empty and takes MaterialRegistry reference.
  - Implemented getCell, setCell, swapBuffers, and toIndex helpers.
  - Core update() method implements material interactions:
    - Iterates grid bottom-up.
    - Sand: Falls if space below is less dense (swaps). If blocked, attempts to fall to a less dense diagonal cell (moves, original becomes Empty). Diagonal check order is randomized.
    - Water: Falls if space below is less dense (swaps). If blocked, attempts horizontal dispersion by finding the furthest less dense cell (Empty) within a limit, in a random direction (left/right), and moves there (original becomes Empty).
  - All simulation reads from m_readCells, writes to m_writeCells.
  - Grid::update() signature changed to accept an unused deltaTime to match Engine.

- Engine:
  - Grid is now initialized with a reference to MaterialRegistry.
  - Engine::run() loop now calls grid.swapBuffers() after grid.update().